### PR TITLE
🎨:アドミン放送を作成ページUI実装

### DIFF
--- a/src/pages/admin/settings.tsx
+++ b/src/pages/admin/settings.tsx
@@ -1,0 +1,45 @@
+import { BaseLayout } from "src/components/Layouts/BaseLayout";
+
+const Setting = () => {
+  return (
+    <BaseLayout title="放送を作成">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="py-10 mx-auto text-4xl font-bold text-gray-900">
+          放送を作成
+        </h1>
+        <form>
+          <div className="flex flex-col gap-10 w-full">
+            <div className="w-full text-left">
+              <input
+                type="text"
+                id=""
+                name=""
+                className="py-1 px-3 w-full text-base leading-8 text-gray-500 bg-white rounded-sm border border-gray-300 focus:ring outline-none"
+                defaultValue="タイトルを入力する"
+              />
+            </div>
+            <div className="w-full text-left ">
+              <input
+                type="date"
+                id=""
+                name=""
+                className="py-1 px-3 w-full text-base leading-8 text-gray-500 bg-white rounded-sm border border-gray-300 focus:ring outline-none"
+                defaultValue="2021/09/03"
+              />
+            </div>
+            <div className=" space-x-4 w-full text-center">
+              <button className="py-3 px-8 text-white bg-light-blue-600 rounded-md">
+                保存する
+              </button>
+              <button className="py-3 px-8 ml-8 text-light-blue-700 bg-light-blue-100 rounded-md">
+                キャンセル
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </BaseLayout>
+  );
+};
+
+export default Setting;


### PR DESCRIPTION
## 変更の概要

- 変更の概要
- Admin　の　放送を作成ページ　UI作成
- [jira](https://qinspringdevelopment.atlassian.net/browse/EGI-14)
- [figma](https://www.figma.com/file/SM5vxSjDcNI6V6HOtHLaB4/Trivia?node-id=187%3A1484)


## やったこと

- [x] やったこと
- [ ] やっていること

## 追加内容

- Admin　の　放送を作成ページ
- pages　配下に　adminフォルダを追加し　setting.tsx作成しました。

## 影響範囲

- UIのみ構築でまだメンバー、システムに影響する部分はまだありません。


サンプル

1. `yarn dev`で起動
2. `localhost:3000/admin/setting`をブラウザで開く

## 課題

- DBとのやりとり。

## 備考

- UIのみ作成。FormのType＝"date"にしました。どのように入力内容がかえってくるのかわからない