### PR TITLE
Feature/egi 34 ログインしていない場合のリダイレクト処理を追加

### DIFF
--- a/src/components/Layouts/Header/index.tsx
+++ b/src/components/Layouts/Header/index.tsx
@@ -1,5 +1,5 @@
 import { UserIcon } from "@heroicons/react/solid";
-import { useSession } from "next-auth/client";
+import { signOut, useSession } from "next-auth/client";
 
 export const Header = () => {
   const [session] = useSession();
@@ -14,6 +14,12 @@ export const Header = () => {
             エンジビアの泉
           </h1>
         </div>
+        <button
+          onClick={() => signOut({ callbackUrl: "/" })}
+          className="py-2 px-4 hover:bg-gray-100 rounded-md border-2"
+        >
+          ログアウト
+        </button>
         {session?.user ? (
           /* Todo: next.jsのImageが使えないので一旦このまま */
           <img

--- a/src/lib/auth/AuthCheck.tsx
+++ b/src/lib/auth/AuthCheck.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/client";
+
+type props = {
+  children: any;
+  pathname: string;
+};
+
+/**ログインチェックをしないPath */
+const isNotAuthPaths = ["/"];
+const loginPath = "/";
+const loggedInRedirect = "/broadcast";
+
+export const Auth = ({ children, pathname }: props) => {
+  const [session, loading] = useSession();
+  const router = useRouter();
+  const isUser = session?.user;
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isUser) router.push(loginPath);
+  }, [isUser, loading]);
+
+  if (isUser && pathname === loginPath) {
+    router.push(loggedInRedirect);
+  }
+  if (isUser || isNotAuthPaths.includes(pathname)) {
+    return children;
+  }
+  return <div>Loading...</div>;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from "next/app";
 import "../styles/globals.css";
 import { Provider } from "next-auth/client";
+import { Auth } from "src/lib/auth/AuthCheck";
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps, router }: AppProps) {
   return (
     <Provider session={pageProps.session}>
-      <Component {...pageProps} />
+      <Auth pathname={router.pathname}>
+        <Component {...pageProps} />
+      </Auth>
     </Provider>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,12 +34,6 @@ export default function Home() {
             <SlackIcon />
             <p className="ml-2">Sign in with Slack</p>
           </button>
-          <button
-            onClick={() => signOut({ callbackUrl: "/" })}
-            className="py-2 px-4 mt-4 hover:bg-gray-100 rounded-md border-2"
-          >
-            Sign Out
-          </button>
         </div>
         <img
           className="object-cover w-[57%] h-screen"


### PR DESCRIPTION
## 変更の概要

- ログインしている場合は、`http://localhost:3000`を開いた際に`broacsat`に遷移させる
- ログインしていない場合、`broadcast`ページや他ページは開けずにログイン画面に遷移させる
- [jira](https://qinspringdevelopment.atlassian.net/browse/EGI-34)

## なぜこの変更をするのか

- ログインしていない場合は、broadcastページなどは表示させたくない
- ログイン済みであれば、ログイン画面に来た際に自動でbroadcastぺページを表示させたいため

## やったこと

- [x] ログイン済みかどうかをチェックする関数を追加
- [x] `_app.tsx`で読み込んで全ページでログイン済みかどうかをチェックするようにする
- [x] ログイン画面にあったSign Out ボタンを削除（ログイン済みであれば、`broadcast`にリダイレクトされ開けないため）
- [x] ヘッダーにログアウトボタンを追加

## どうやるのか

- ログインしていない状態で `http://localhost:3000/broadcast`

サンプル
ログインしていない状態
1. `yarn dev`で起動
2. `http://localhost:3000/broadcast`をブラウザで開く
3. `http://localhost:3000`に遷移することを確認

ログインしている状態
1. `yarn dev`で起動
2. `http://localhost:3000`をブラウザで開く
3. `http://localhost:3000/broadcast`に遷移することを確認

## 課題

- `Auth`のPropsの`children`の型を何にすれば良いかがわかってない。　一旦anyにしている。
