### PR TITLE
✨Labelコンポーネント作成しました

### DIFF
--- a/src/components/Label/index.stories.tsx
+++ b/src/components/Label/index.stories.tsx
@@ -12,17 +12,17 @@ const Template: Story<Props> = (args) => <Label {...args} />;
 export const BeforeBroadcast = Template.bind({});
 
 BeforeBroadcast.args = {
-  label: "放送前・エンジビア募集中",
+  status: "BEFORE",
 };
 
 export const OnAirBroadcast = Template.bind({});
 
 OnAirBroadcast.args = {
-  label: "放送中",
+  status: "IN_PROGRESS",
 };
 
 export const AfterBroadcast = Template.bind({});
 
 AfterBroadcast.args = {
-  label: "放送済",
+  status: "DONE",
 };

--- a/src/components/Label/index.stories.tsx
+++ b/src/components/Label/index.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { Label, Props } from "./index";
+
+export default {
+  component: Label,
+  title: "Components/Label",
+} as Meta;
+
+const Template: Story<Props> = (args) => <Label {...args} />;
+
+export const BeforeBroadcast = Template.bind({});
+
+BeforeBroadcast.args = {
+  label: "放送前・エンジビア募集中",
+};
+
+export const OnAirBroadcast = Template.bind({});
+
+OnAirBroadcast.args = {
+  label: "放送中",
+};
+
+export const AfterBroadcast = Template.bind({});
+
+AfterBroadcast.args = {
+  label: "放送済",
+};

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,23 @@
+import { FC } from "react";
+
+export type Props = {
+  label: string;
+};
+
+export const Label: FC<Props> = ({ label }) => {
+  return (
+    <>
+      <span
+        className={`py-1 px-3 text-sm rounded-full ${
+          label === "放送前・エンジビア募集中"
+            ? "text-orange-700 bg-orange-100"
+            : label === "放送中"
+            ? "text-green-700 bg-green-100"
+            : "text-gray-900 bg-gray-200"
+        }`}
+      >
+        {label}
+      </span>
+    </>
+  );
+};

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,8 +1,4 @@
 import { FC } from "react";
-//classNameの文字列を配列として読み込んで、スペースをつけて返す関数
-const classNamesSet = (...classes: string[]) => {
-  return classes.filter(Boolean).join(" ");
-};
 
 export type Props = {
   className?: string;
@@ -31,10 +27,7 @@ export const Label: FC<Props> = ({ className, status }) => {
   }
   return (
     <div className={className}>
-      <span
-        className={classNamesSet(textColor, "py-1 px-3 text-sm rounded-full")}
-      >
-        {/* <span className={"py-1 px-3 text-sm rounded-full ${textColor}"}> */}
+      <span className={`py-1 px-3 text-sm rounded-full ${textColor}`}>
         {broadcastStatus}
       </span>
     </div>

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,23 +1,28 @@
 import { FC } from "react";
 
 export type Props = {
-  label: string;
+  className?: string;
+  status: string;
 };
 
-export const Label: FC<Props> = ({ label }) => {
+export const Label: FC<Props> = ({ className, status }) => {
   return (
-    <>
+    <div className={className}>
       <span
         className={`py-1 px-3 text-sm rounded-full ${
-          label === "放送前・エンジビア募集中"
+          status === "BEFORE"
             ? "text-orange-700 bg-orange-100"
-            : label === "放送中"
+            : status === "IN_PROGRESS"
             ? "text-green-700 bg-green-100"
             : "text-gray-900 bg-gray-200"
         }`}
       >
-        {label}
+        {status === "BEFORE"
+          ? "放送前・エンジビア募集中"
+          : status === "IN_PROGRESS"
+          ? "放送中"
+          : "放送済"}
       </span>
-    </>
+    </div>
   );
 };

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,27 +1,41 @@
 import { FC } from "react";
+//classNameの文字列を配列として読み込んで、スペースをつけて返す関数
+const classNamesSet = (...classes: string[]) => {
+  return classes.filter(Boolean).join(" ");
+};
 
 export type Props = {
   className?: string;
-  status: string;
+  status: "BEFORE" | "IN_PROGRESS" | "DONE";
 };
 
 export const Label: FC<Props> = ({ className, status }) => {
+  let broadcastStatus = "";
+  let textColor = "";
+
+  switch (status) {
+    case "BEFORE":
+      broadcastStatus = "放送前・エンジビア募集中";
+      textColor = "text-orange-700 bg-orange-100";
+      break;
+    case "IN_PROGRESS":
+      broadcastStatus = "放送中";
+      textColor = "text-green-700 bg-green-100";
+      break;
+    case "DONE":
+      broadcastStatus = "放送済";
+      textColor = "text-gray-900 bg-gray-200";
+      break;
+    default:
+      break;
+  }
   return (
     <div className={className}>
       <span
-        className={`py-1 px-3 text-sm rounded-full ${
-          status === "BEFORE"
-            ? "text-orange-700 bg-orange-100"
-            : status === "IN_PROGRESS"
-            ? "text-green-700 bg-green-100"
-            : "text-gray-900 bg-gray-200"
-        }`}
+        className={classNamesSet(textColor, "py-1 px-3 text-sm rounded-full")}
       >
-        {status === "BEFORE"
-          ? "放送前・エンジビア募集中"
-          : status === "IN_PROGRESS"
-          ? "放送中"
-          : "放送済"}
+        {/* <span className={"py-1 px-3 text-sm rounded-full ${textColor}"}> */}
+        {broadcastStatus}
       </span>
     </div>
   );

--- a/src/pages/broadcast_entry.tsx
+++ b/src/pages/broadcast_entry.tsx
@@ -1,0 +1,15 @@
+import { BaseLayout } from "src/components/Layouts/BaseLayout";
+import { Label } from "src/components/Label";
+
+const BroadcastEntry = () => {
+  // Todo: BEFORE|IN_PROGRESS|DONEいずれかが入る Hooks導入次第変更
+  const status = "BEFORE";
+
+  return (
+    <BaseLayout title="エンジビアを入力">
+      <Label status={status} />
+    </BaseLayout>
+  );
+};
+
+export default BroadcastEntry;


### PR DESCRIPTION
## 変更の概要

- 変更の概要
- 放送前・放送中・放送済　ラベルをコンポーネント化にする。
- [jira](https://qinspringdevelopment.atlassian.net/browse/EGI-40)

![image](https://user-images.githubusercontent.com/70996914/140918977-04e6875d-a713-46c4-a44a-c03c40dbf5e5.png)
![image](https://user-images.githubusercontent.com/70996914/140919545-67ecaa72-33fd-4116-90c1-00a585c0ae37.png)
![image](https://user-images.githubusercontent.com/70996914/140919597-59c6a5ee-1c6d-4940-a7e7-aa7a431669f8.png)

## やったこと

- [x] コンポーネントに追加

- [x] storybookに追加

## 追加内容
- BroadcastListからラベル部分を取り出しました。
- ComponentsにLabelコンポーネントを追加
- 放送前・放送中・放送済　ラベルを可視化しました。

## 影響範囲

- すべてのページの放送前・放送中・放送済　ラベルに影響します。


サンプル

1. `yarn storybook`で起動
2. `localhost:6006/`をブラウザで開く

## 課題

- BroadcastListからラベル部分をそのまま持ってきてコンポーネント作成のみで状態管理はまだ。
- 今後どのように作ったほうが良いのかまだわかっていない。


## 備考

- まだ状態管理はしていません。