### PR TITLE
[EG-17] 共通ボタンのスタイリングを変更

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,15 +1,34 @@
-import { FC, ReactNode } from "react";
+import type { FC, ReactNode, MouseEventHandler } from "react";
 
 export interface Props {
   isSubmitting: boolean;
   type: "button" | "submit" | "reset";
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  primary: boolean;
   children?: ReactNode;
 }
 
-export const Button: FC<Props> = ({ isSubmitting, type, children }) => {
+export const Button: FC<Props> = ({
+  isSubmitting,
+  type,
+  onClick,
+  primary,
+  children,
+}) => {
   return (
     <>
-      <button disabled={isSubmitting} type={type} className="bg-blue-400">
+      <button
+        disabled={isSubmitting}
+        type={type}
+        onClick={onClick}
+        className={`py-2 px-4 mr-2 rounded-md
+          ${
+            primary
+              ? "bg-light-blue-600 text-white"
+              : "bg-light-blue-100 text-light-blue-700"
+          } 
+        `}
+      >
         {children}
       </button>
     </>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,36 +1,36 @@
 import type { FC, ReactNode, MouseEventHandler } from "react";
 
-export interface Props {
+export type Props = {
   isSubmitting: boolean;
   type: "button" | "submit" | "reset";
   onClick: MouseEventHandler<HTMLButtonElement>;
-  primary: boolean;
-  children?: ReactNode;
-}
+  isPrimary: boolean;
+  className?: string;
+  children: ReactNode;
+};
 
 export const Button: FC<Props> = ({
   isSubmitting,
   type,
   onClick,
-  primary,
+  isPrimary,
+  className,
   children,
 }) => {
   return (
-    <>
-      <button
-        disabled={isSubmitting}
-        type={type}
-        onClick={onClick}
-        className={`py-2 px-4 mr-2 rounded-md
+    <button
+      disabled={isSubmitting}
+      type={type}
+      onClick={onClick}
+      className={`py-2 px-4 mr-2 rounded-md ${className}
           ${
-            primary
+            isPrimary
               ? "bg-light-blue-600 text-white"
               : "bg-light-blue-100 text-light-blue-700"
           } 
         `}
-      >
-        {children}
-      </button>
-    </>
+    >
+      {children}
+    </button>
   );
 };


### PR DESCRIPTION
## 変更の概要

- 変更の概要
- 共通ボタンのスタイリングを変更
- [jira](https://qinspringdevelopment.atlassian.net/browse/EGI-17)

## なぜこの変更をするのか

- 複数箇所で使用するボタンを共通化し、変更を容易に反映するため

## やったこと

- [x] src/components/Button.tsxに`primary` propsを追加し、booleanでプライマリーボタンかどうかを選べる

## 変更内容

<img width="848" alt="CleanShot 2021-11-11 at 13 30 20@2x" src="https://user-images.githubusercontent.com/15007672/141237353-33dbf29e-67d9-44eb-80ba-66b20a73e7d3.png">

## 影響範囲
ボタン使用画面

