### PR TITLE
フィーチャー中のエンジビアがあれば、他のエンジビアの移動はできないようにする

### DIFF
--- a/src/components/Engivia/SortableItem/index.tsx
+++ b/src/components/Engivia/SortableItem/index.tsx
@@ -7,11 +7,29 @@ import { adjustScale } from "@dnd-kit/core/dist/utilities";
 type Props = {
   engivia: EngiviaType;
   broadcast: BroadcastType | undefined;
+  inFeatureId: string | undefined;
 };
 
-export const SortableItem: FC<Props> = ({ engivia, broadcast }) => {
-  const isDisable = broadcast?.status === "IN_PROGRESS" ? false : true;
-  const sortable = useSortable({ id: engivia.id, disabled: isDisable });
+export const SortableItem: FC<Props> = ({
+  engivia,
+  broadcast,
+  inFeatureId,
+}) => {
+  const isDisable = (engiviaId: string) => {
+    /** 放送中でなければ、移動不可 */
+    if (broadcast?.status !== "IN_PROGRESS") {
+      return true;
+    }
+    /** feature中のidがある場合、他のengiviaの移動は不可 */
+    if (inFeatureId !== "" && inFeatureId !== engiviaId) {
+      return true;
+    }
+    return false;
+  };
+  const sortable = useSortable({
+    id: engivia.id,
+    disabled: isDisable(engivia.id),
+  });
   const { attributes, setNodeRef, listeners, transform, transition } = sortable;
 
   const style = {

--- a/src/constant/initialState.ts
+++ b/src/constant/initialState.ts
@@ -1,3 +1,5 @@
+import { EngiviaType } from "src/types/interface";
+
 export const initialBroadcastInfo = {
   broadCastUrl: "",
   broadCastingDate: new Date().toISOString(),
@@ -7,7 +9,7 @@ export const initialBroadcastInfo = {
   title: "",
 };
 
-export const initialEngiviaInfo = {
+export const initialEngiviaInfo: EngiviaType = {
   body: "",
   createdAt: new Date().toISOString(),
   engiviaNumber: 0,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,10 @@
 import { firebase, db } from "src/lib/firebase";
-import { WithOutToken, BroadcastFormType, UserType } from "src/types/interface";
+import {
+  WithOutToken,
+  BroadcastFormType,
+  UserType,
+  featureStatusType,
+} from "src/types/interface";
 
 export const getUser = async (uid: string) => {
   const data = await db
@@ -80,6 +85,20 @@ export const updateBroadcastFeatureId = async (
       });
     await broadcastRef.set({ featureId: engivia?.id }, { merge: true });
   }
+};
+
+export const updateEngiviaFeatureStatus = async (
+  broadcastId: string,
+  engiviaId: string,
+  featureStatus: featureStatusType
+) => {
+  const engiviaRef = db
+    .collection("broadcasts")
+    .doc(broadcastId)
+    .collection("engivias")
+    .doc(engiviaId);
+
+  await engiviaRef.set({ featureStatus: featureStatus }, { merge: true });
 };
 
 export const getEngivias = async (broadcastId: string) => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -273,6 +273,19 @@ export const incrementEngiviaNumber = async (
   broadcastId: string,
   engiviaId: string
 ) => {
+  const engivia = await db
+    .collection("broadcasts")
+    .doc(broadcastId)
+    .collection("engivias")
+    .doc(engiviaId)
+    .get()
+    .then((snapshot) => {
+      return snapshot.data();
+    });
+
+  /**エンジビアNoが登録済みなら処理スキップ */
+  if (engivia?.engiviaNumber) return;
+
   const broadcastRef = await db.collection("broadcasts").doc(broadcastId);
   broadcastRef.set(
     { engiviaCurrentCount: firebase.firestore.FieldValue.increment(1) },
@@ -292,7 +305,6 @@ export const incrementEngiviaNumber = async (
     .doc(broadcastId)
     .collection("engivias")
     .doc(engiviaId);
-
   if (broadcast) {
     engiviaRef.set(
       { engiviaNumber: broadcast.engiviaCurrentCount },

--- a/src/pages/admin/broadcasting.tsx
+++ b/src/pages/admin/broadcasting.tsx
@@ -150,6 +150,22 @@ const Broadcasting = ({
     });
   };
 
+  useEffect(() => {
+    return () => {
+      items.before.forEach((engivia) =>
+        updateEngiviaFeatureStatus(broadcastId, engivia.id, "BEFORE")
+      );
+
+      items.inFeature.forEach((engivia) =>
+        updateEngiviaFeatureStatus(broadcastId, engivia.id, "IN_FEATURE")
+      );
+
+      items.done.forEach((engivia) =>
+        updateEngiviaFeatureStatus(broadcastId, engivia.id, "DONE")
+      );
+    };
+  });
+
   return (
     <BaseLayout title="放送一覧">
       <div className="mx-auto max-w-6xl">
@@ -191,7 +207,6 @@ const Broadcasting = ({
             collisionDetection={collisionDetection}
             onDragStart={({ active }) => {
               setActiveId(active.id);
-              //謎
               setClonedItems(items);
             }}
             onDragOver={({ active, over }) => {
@@ -270,17 +285,14 @@ const Broadcasting = ({
               switch (overContainer) {
                 case "before": {
                   setInFeatureId("");
-                  updateEngiviaFeatureStatus(broadcastId, overId, "BEFORE");
                   updateBroadcastFeatureId(broadcastId, overId, true);
                   break;
                 }
                 case "inFeature":
                   setInFeatureId(overId);
-                  updateEngiviaFeatureStatus(broadcastId, overId, "IN_FEATURE");
                   break;
                 case "done":
                   setInFeatureId("");
-                  updateEngiviaFeatureStatus(broadcastId, overId, "DONE");
                   updateBroadcastFeatureId(broadcastId, overId, true);
                   break;
               }

--- a/src/pages/admin/broadcasting.tsx
+++ b/src/pages/admin/broadcasting.tsx
@@ -236,12 +236,6 @@ const Broadcasting = ({
               }
             }}
             onDragEnd={({ active, over }) => {
-              if (items["フィーチャー中"].length === 1) {
-                // その他はdisabledにしたい
-                console.log("disabledが発動して欲しい");
-              } else {
-                console.log("いいよ");
-              }
               const activeContainer = findContainer(active.id);
               if (!activeContainer) {
                 setActiveId(null);
@@ -263,7 +257,6 @@ const Broadcasting = ({
                 const overIndex = items[overContainer].findIndex(
                   (item) => item.id === overId
                 );
-                console.log(items);
 
                 if (activeIndex !== overIndex) {
                   setItems((items) => ({
@@ -296,6 +289,7 @@ const Broadcasting = ({
                         key={engivia.id}
                         engivia={engivia}
                         broadcast={broadcast}
+                        inFeatureId={inFeatureId}
                       />
                     ))}
                     {inFeatureId === "" &&

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -17,11 +17,14 @@ export type JoinUserType = {
   image: string;
   uid: string;
 };
+
+export type featureStatusType = "BEFORE" | "IN_FEATURE" | "DONE";
+
 export type EngiviaType = {
   body: string;
   createdAt: string;
   engiviaNumber: number;
-  featureStatus: string;
+  featureStatus: featureStatusType;
   id: string;
   postUser: PostUserType;
   totalLikes: number;


### PR DESCRIPTION
## 変更の概要

- フィーチャー中のエンジビアがあれば、他のエンジビアをdrag and dropできないようにする
- エンジビアNumberが発番済みであれば、「タイトルコール」を押してもカウントアップしないようにする。（上書きしない）
- リロードした際に、featureStatusを保持するようにする

## なぜこの変更をするのか

- [仕様](https://qinsalon.slack.com/archives/C02GG1XRC67/p1634280640294600)に沿うようにするため
