### PR TITLE
fix: firebase authenticationと連携するように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@heroicons/react": "^1.0.4",
     "@hookform/resolvers": "^2.8.3",
     "@tailwindcss/postcss7-compat": "^2.2.17",
+    "axios": "^0.24.0",
     "date-fns": "^2.25.0",
     "firebase": "8.6.2",
     "firebase-admin": "^10.0.0",

--- a/src/components/Layouts/Header/index.tsx
+++ b/src/components/Layouts/Header/index.tsx
@@ -6,6 +6,7 @@ import { Fragment } from "react";
 import { UserIcon } from "@heroicons/react/solid";
 import { LogoutIcon, IdentificationIcon } from "@heroicons/react/outline";
 import { signOut, useSession } from "next-auth/client";
+import { auth } from "src/lib/firebase";
 
 export const Header = () => {
   const [session] = useSession();
@@ -85,7 +86,10 @@ export const Header = () => {
                       <Menu.Item>
                         {({ active }) => (
                           <button
-                            onClick={() => signOut({ callbackUrl: "/" })}
+                            onClick={() => {
+                              auth.signOut();
+                              signOut({ callbackUrl: "/" });
+                            }}
                             className={`${
                               active
                                 ? "bg-light-blue-600 text-white"

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -11,5 +11,7 @@ if (!admin.apps.length) {
 }
 
 const db = admin.firestore();
+const adminAuth = admin.auth();
 
 export { db };
+export { adminAuth };

--- a/src/pages/api/auth/firebaseAuth.ts
+++ b/src/pages/api/auth/firebaseAuth.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { adminAuth } from "src/lib/firebase-admin";
+
+export type CustomTokenResponse = {
+  token?: string;
+  errorMessage?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CustomTokenResponse>
+) {
+  const userId = req.body?.userId;
+  if (userId) {
+    const customToken = await adminAuth.createCustomToken(userId);
+    res.status(200).json({ token: customToken });
+  } else {
+    res.status(400).json({ errorMessage: "userId is required" });
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Home() {
           <button
             onClick={() =>
               signIn("slack", {
-                callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/broadcasts`,
+                callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/login`,
               })
             }
             className="flex items-center py-2 px-4 hover:bg-gray-100 rounded-md border-2"

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,37 @@
+import { NextPage } from "next";
+import { useSession } from "next-auth/client";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import axios from "axios";
+import { auth } from "src/lib/firebase";
+
+const Login: NextPage = () => {
+  const [session] = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    const getToken = async () => {
+      const result = await axios.post(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/firebaseAuth`,
+        { userId: session?.user.id }
+      );
+      return result.data.token;
+    };
+
+    getToken()
+      .then((token) => {
+        auth.signInWithCustomToken(token);
+      })
+      .then(() => {
+        router.push("/broadcasts");
+      })
+      .catch((e) => {
+        console.log(e);
+        router.push("/");
+      });
+  }, []);
+
+  return <div></div>;
+};
+
+export default Login;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -20,7 +20,7 @@ const Login: NextPage = () => {
 
     getToken()
       .then((token) => {
-        auth.signInWithCustomToken(token);
+        return auth.signInWithCustomToken(token);
       })
       .then(() => {
         router.push("/broadcasts");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,6 +4041,13 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -6651,6 +6658,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.14.4:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 変更の概要

- signInした際に、frebase authenticationと連携するように修正（カスタムtoken認証）
- signOutした際に、firebase authenticationからもsignOutするように修正
- `[...nextauth]`内でデータ取得する際に、認証処理をしてから取得するように修正


## なぜこの変更をするのか
- firebase rulesを追加している際に、認証済みなのかどうかや ログインしているユーザーのidを取得するために必要なため
  - これをしないと、ユーザー情報編集ができるのは自分のuserIdだけなどの条件付与ができない

## 確認方法
- yarn devで起動
- localhost:3000にアクセス
- ログイン
- 適当に操作
　問題なく操作できることを確認。　機能追加したわけではないので、操作でエラーが出ていなければ大丈夫。