### PR TITLE
add: joinUserをカウントするフィールドをエンジビアに追加

### DIFF
--- a/src/components/Engivia/EngiviaList/index.tsx
+++ b/src/components/Engivia/EngiviaList/index.tsx
@@ -29,7 +29,13 @@ export const EngiviaList: FC<Props> = ({ engivias }) => {
                 </span>
               </div>
               <div className="inline py-3 px-10 text-4xl font-bold text-[#0284C7] bg-[#FEF3C7] rounded-lg">
-                <span>{engivia?.totalLikes}</span>
+                <span>
+                  {engivia.joinUsersCount != 0
+                    ? Math.round(
+                        (engivia.totalLikes / engivia.joinUsersCount) * 5 * 10
+                      ) / 10
+                    : 0}
+                </span>
                 <span className="text-xl">へえ</span>
               </div>
             </div>

--- a/src/constant/initialState.ts
+++ b/src/constant/initialState.ts
@@ -21,4 +21,5 @@ export const initialEngiviaInfo: EngiviaType = {
     id: "",
   },
   totalLikes: 0,
+  joinUsersCount: 0,
 };

--- a/src/hooks/useSubscribe.tsx
+++ b/src/hooks/useSubscribe.tsx
@@ -143,7 +143,7 @@ export const useSubscribeTotalLikes = (
   engiviaId: string | undefined
 ) => {
   const soundFlgRef = useRef(false);
-  const [totalLikes, setTotalLikes] = useState<number>(0);
+  const [totalLikes, setTotalLikes] = useState<number | null>(null);
   const [play] = useSound("/hee_low.mp3");
 
   useEffect(() => {
@@ -154,19 +154,21 @@ export const useSubscribeTotalLikes = (
       .doc(engiviaId)
       .onSnapshot(async (snapshot) => {
         const engiviaDoc = await snapshot.data();
-        if (engiviaDoc) {
-          setTotalLikes(engiviaDoc.totalLikes);
-          soundFlgRef.current && play();
-          soundFlgRef.current = true;
-        } else {
-          setTotalLikes(0);
-          soundFlgRef.current = false;
-        }
+        setTotalLikes(engiviaDoc?.totalLikes);
       });
-
     return () => unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [broadcastId, engiviaId]);
+
+  //へぇ数が変わった時だけ音を出す
+  useEffect(() => {
+    if (totalLikes != null) {
+      soundFlgRef.current && play();
+      soundFlgRef.current = true;
+    } else {
+      soundFlgRef.current = false;
+    }
+  }, [totalLikes]);
 
   return totalLikes;
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -326,4 +326,15 @@ export const addJoinUser = async (
       image: user.image,
       id: user.id,
     });
+
+  const engiviaRef = await db
+    .collection("broadcasts")
+    .doc(broadcastId)
+    .collection("engivias")
+    .doc(engiviaId);
+
+  engiviaRef.set(
+    { joinUsersCount: firebase.firestore.FieldValue.increment(1) },
+    { merge: true }
+  );
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,6 +3,7 @@ import {
   WithOutToken,
   BroadcastFormType,
   featureStatusType,
+  EngiviaType,
 } from "src/types/interface";
 import { ReqUser } from "src/lib/users";
 import { User } from "next-auth";
@@ -125,7 +126,7 @@ export const createEngivia = async (
     .doc(broadcastId)
     .collection("engivias")
     .doc();
-  const engivia = {
+  const engivia: EngiviaType = {
     body: engiviaBody,
     createdAt: new Date().toISOString(),
     engiviaNumber: null,
@@ -137,6 +138,7 @@ export const createEngivia = async (
       id: user.id,
     },
     totalLikes: 0,
+    joinUsersCount: 0,
   };
   engiviaRef.set(engivia);
 

--- a/src/pages/users/broadcasting.tsx
+++ b/src/pages/users/broadcasting.tsx
@@ -32,7 +32,9 @@ const Broadcasting: NextPage = () => {
   const totalLikes = useSubscribeTotalLikes(broadcastId, featureEngivia?.id);
   const joinUsers = useSubscribeJoinUsers(broadcastId, featureEngivia?.id);
   const currentTotalLikes =
-    Math.round((totalLikes / joinUsers.length) * 5 * 10) / 10;
+    joinUsers.length != 0
+      ? Math.round((totalLikes / joinUsers.length) * 5 * 10) / 10
+      : 0;
 
   useEffect(() => {
     if (broadcast?.status === "DONE") {

--- a/src/pages/users/broadcasting.tsx
+++ b/src/pages/users/broadcasting.tsx
@@ -32,7 +32,7 @@ const Broadcasting: NextPage = () => {
   const totalLikes = useSubscribeTotalLikes(broadcastId, featureEngivia?.id);
   const joinUsers = useSubscribeJoinUsers(broadcastId, featureEngivia?.id);
   const currentTotalLikes =
-    joinUsers.length != 0
+    joinUsers.length != 0 && totalLikes
       ? Math.round((totalLikes / joinUsers.length) * 5 * 10) / 10
       : 0;
 

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -20,6 +20,7 @@ export type EngiviaType = {
   id: string;
   postUser: PostUserType;
   totalLikes: number;
+  joinUsersCount: number;
 };
 
 export type BroadcastType = {

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -15,7 +15,7 @@ export type featureStatusType = "BEFORE" | "IN_FEATURE" | "DONE";
 export type EngiviaType = {
   body: string;
   createdAt: string;
-  engiviaNumber: number;
+  engiviaNumber: number | null;
   featureStatus: featureStatusType;
   id: string;
   postUser: PostUserType;


### PR DESCRIPTION
## 変更の概要

- joinUserにデータがいくつかあるかをカウントする処理を追加
- 放送終了後ページを表示する際の、totalLikesに計算を追加

## 意図
- 管理者画面や放送終了後の画面を表示する際に　参加人数をカウントするためだけにjoinUserを取得するのが面倒なため