### PR TITLE
[WIP][EGI-56]管理者ページのfeature中エンジビアカードに参加者人数とエンジビア数を表示

### DIFF
--- a/src/components/Broadcast/BroadcastItem/index.tsx
+++ b/src/components/Broadcast/BroadcastItem/index.tsx
@@ -35,7 +35,6 @@ export const BroadcastItem: FC<Props> = ({ broadcast }) => {
         query: { id: id },
       });
     } else if (status === "IN_PROGRESS") {
-      // createJoinUsers(id, engivia.id, user);
       router.push({
         pathname: "/users/broadcasting",
         query: { id: id },

--- a/src/components/Engivia/SortableItem/index.tsx
+++ b/src/components/Engivia/SortableItem/index.tsx
@@ -64,7 +64,11 @@ export const SortableItem: FC<Props> = ({
                 src={engivia.postUser.image}
                 alt="avatar"
               />
-              <span className="text-sm">{engivia.postUser.name}</span>
+              <span className="text-sm">
+                {engivia.postUser.name.length > 18
+                  ? `${engivia.postUser.name.slice(0, 18)}…`
+                  : engivia.postUser.name}
+              </span>
             </div>
           </div>
           {inFeatureId === engivia.id && (

--- a/src/components/Engivia/SortableItem/index.tsx
+++ b/src/components/Engivia/SortableItem/index.tsx
@@ -2,6 +2,10 @@ import type { FC } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { BroadcastType, EngiviaType } from "src/types/interface";
+import {
+  useSubscribeJoinUsers,
+  useSubscribeTotalLikes,
+} from "src/hooks/useSubscribe";
 
 type Props = {
   engivia: EngiviaType;
@@ -14,6 +18,18 @@ export const SortableItem: FC<Props> = ({
   broadcast,
   inFeatureId,
 }) => {
+  const totalLikes = useSubscribeTotalLikes(
+    broadcast?.id as string,
+    engivia.id
+  );
+  const joinUsersCount = useSubscribeJoinUsers(
+    broadcast?.id as string,
+    engivia.id
+  ).length;
+
+  const currentTotalLikes =
+    Math.round((totalLikes / joinUsersCount) * 5 * 10) / 10;
+
   const isDisable = (engiviaId: string) => {
     /** 放送中でなければ、移動不可 */
     if (broadcast?.status !== "IN_PROGRESS") {
@@ -39,14 +55,28 @@ export const SortableItem: FC<Props> = ({
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       <div className="z-10 py-4 px-4 bg-white rounded-md shadow-md">
-        <span className="text-lg">{engivia.body}</span>
-        <div className="flex items-center mt-4">
-          <img
-            className="mr-2 h-6 rounded-full"
-            src={engivia.postUser.image}
-            alt="avatar"
-          />
-          <span>{engivia.postUser.name}</span>
+        <div className="flex flex-row justify-between items-baseline">
+          <div>
+            <span className="text-lg">{engivia.body}</span>
+            <div className="flex items-center mt-4">
+              <img
+                className="mr-1 h-5 rounded-full"
+                src={engivia.postUser.image}
+                alt="avatar"
+              />
+              <span className="text-sm">{engivia.postUser.name}</span>
+            </div>
+          </div>
+          {inFeatureId === engivia.id && (
+            <div className="flex flex-col space-y-2">
+              <span className="py-1 px-2 text-xs text-gray-600 bg-gray-200 rounded-full">
+                {`人: ${joinUsersCount}`}
+              </span>
+              <span className="py-1 px-2 text-xs text-gray-600 bg-gray-200 rounded-full">
+                {`数: ${currentTotalLikes}`}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Engivia/SortableItem/index.tsx
+++ b/src/components/Engivia/SortableItem/index.tsx
@@ -73,7 +73,7 @@ export const SortableItem: FC<Props> = ({
                 {`人: ${joinUsersCount}`}
               </span>
               <span className="py-1 px-2 text-xs text-gray-600 bg-gray-200 rounded-full">
-                {`数: ${currentTotalLikes}`}
+                {`数: ${currentTotalLikes ? currentTotalLikes : 0}`}
               </span>
             </div>
           )}

--- a/src/constant/initialState.ts
+++ b/src/constant/initialState.ts
@@ -15,6 +15,7 @@ export const initialEngiviaInfo: EngiviaType = {
   engiviaNumber: 0,
   featureStatus: "BEFORE",
   id: "",
+  joinUsersCount: 0,
   postUser: {
     image: "",
     name: "",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -131,6 +131,7 @@ export const createEngivia = async (
     engiviaNumber: null,
     featureStatus: "BEFORE",
     id: engiviaRef.id,
+    joinUsersCount: 0,
     postUser: {
       name: user.name,
       image: user.image,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -153,25 +153,6 @@ export const createEngivia = async (
   return engivia;
 };
 
-export const createJoinUsers = async (
-  broadcastId: string,
-  engiviaId: string,
-  user: ReqUser
-) => {
-  db.collection("broadcasts")
-    .doc(broadcastId)
-    .collection("engivias")
-    .doc(engiviaId)
-    .collection("joinUsers")
-    .doc(user.id)
-    .set({
-      likes: 0,
-      name: user.name,
-      image: user.image,
-      iid: user.id,
-    });
-};
-
 export const updateEngivia = async (
   broadcastId: string,
   engiviaId: string,
@@ -327,4 +308,20 @@ export const addJoinUser = async (
       image: user.image,
       id: user.id,
     });
+
+  const joinUserRef2 = await db
+    .collection("broadcasts")
+    .doc(broadcastId)
+    .collection("engivias")
+    .doc(engiviaId)
+    .collection("joinUsers")
+    .get();
+
+  const joinUsersLength = joinUserRef2.docs.length;
+  const engiviaRef = await db
+    .collection("broadcasts")
+    .doc(broadcastId)
+    .collection("engivias")
+    .doc(engiviaId);
+  engiviaRef.set({ joinUsersCount: joinUsersLength }, { merge: true });
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -308,20 +308,4 @@ export const addJoinUser = async (
       image: user.image,
       id: user.id,
     });
-
-  const joinUserRef2 = await db
-    .collection("broadcasts")
-    .doc(broadcastId)
-    .collection("engivias")
-    .doc(engiviaId)
-    .collection("joinUsers")
-    .get();
-
-  const joinUsersLength = joinUserRef2.docs.length;
-  const engiviaRef = await db
-    .collection("broadcasts")
-    .doc(broadcastId)
-    .collection("engivias")
-    .doc(engiviaId);
-  engiviaRef.set({ joinUsersCount: joinUsersLength }, { merge: true });
 };

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -18,6 +18,7 @@ export type EngiviaType = {
   engiviaNumber: number;
   featureStatus: featureStatusType;
   id: string;
+  joinUsersCount: number;
   postUser: PostUserType;
   totalLikes: number;
 };


### PR DESCRIPTION
## 変更の概要
管理者が現在の参加者数やエンジビア数の確認ができるようにする

## なぜこの変更をするのか
管理者は現在の参加者数やエンジビア数がわからないため

## やったこと

- [ ]  useSubscribeJoinUsersを追加し、現在の参加者数を取得
- [ ]  useSubscribeTotalLikesを追加し、現在のエンジビア数を取得

## 変更内容

![CleanShot 2021-12-07 at 11 29 29](https://user-images.githubusercontent.com/15007672/144955258-38eabb71-fd1e-48be-a5ea-41b9c3bb1bb5.png)

## 備考
joinUsersCountを追加したのですが、どこでどのように数値を増やしたら良いかわからなかったので、
現状useSubscribeJoinUsersとuseSubscribeTotalLikesを使用しています:sweat:

- 人 → 参加者人数
- 数→ トータルエンジビア数
という表記にしていますが、もっとわかりやすい表記あればご意見ください！