### PR TITLE
[EGI-46][EGI-47]Header&エンジビアカード storybook登録

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,10 @@
 import "../src/styles/globals.css";
+import * as nextImage from "next/image";
+
+Object.defineProperty(nextImage, "default", {
+  configurable: true,
+  value: (props) => <img {...props} />,
+});
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-lint": "eslint . --ext ts --ext tsx --ext js",
     "format": "prettier --write .",
     "test-all": "yarn check-types && yarn check-format && yarn check-lint && yarn build",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook"
   },
   "dependencies": {

--- a/src/components/Engivia/EngiviaCard/index.stories.tsx
+++ b/src/components/Engivia/EngiviaCard/index.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { EngiviaCard, Props } from "./index";
+
+export default {
+  component: EngiviaCard,
+  title: "Components/EngiviaCard",
+} as Meta;
+
+const Template: Story<Props> = (args) => <EngiviaCard {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  engivia: {
+    id: "1",
+    engiviaNumber: 1,
+    body: "ここにエンジビアが入ります。",
+    createdAt: "おさむ",
+    featureStatus: "BEFORE",
+    postUser: { image: "./15007672.jpeg", name: "おさむ", id: "000000000" },
+    totalLikes: 20,
+  },
+};

--- a/src/components/Engivia/EngiviaCard/index.stories.tsx
+++ b/src/components/Engivia/EngiviaCard/index.stories.tsx
@@ -20,5 +20,6 @@ Default.args = {
     featureStatus: "BEFORE",
     postUser: { image: "./15007672.jpeg", name: "おさむ", id: "000000000" },
     totalLikes: 20,
+    joinUsersCount: 20,
   },
 };

--- a/src/components/Engivia/EngiviaCard/index.tsx
+++ b/src/components/Engivia/EngiviaCard/index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { EngiviaType } from "src/types/interface";
 
-type Props = {
+export type Props = {
   engivia: EngiviaType;
   totalLikes?: number;
 };

--- a/src/components/Layouts/Header/index.stories.tsx
+++ b/src/components/Layouts/Header/index.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { Header } from "./index";
+
+export default {
+  component: Header,
+  title: "Components/Header",
+} as Meta;
+
+const Template: Story = (args) => <Header {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {};


### PR DESCRIPTION
## 変更の概要

- 変更の概要
- EngiviaCard storybookに登録
- [jira](https://qinspringdevelopment.atlassian.net/browse/EGI-47)
- [figma](https://www.figma.com/file/SM5vxSjDcNI6V6HOtHLaB4/Trivia?node-id=132%3A3411)


## やったこと

- [x] storybookで画像を読み込めるようにpackage.json/.storybook/preview.jsを変更
- [x] EngiviaCard storybook登録
- [x] Header storybook登録

## 追加内容

- Header/EngiviaCard　storybookに追加


## サンプル

1. `yarn storybook`で起動
2. `http://localhost:6006/`をブラウザで開く

## 課題

-  classNameも渡ってくるようにしたい。


## 備考


参考にしたURL
https://xenox.dev/next-image-with-storybookjs/