### PR TITLE
[EGI-57]ボタンアニメーション・長い参加者名を省略表示・認証中のローディングアニメーション

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -25,8 +25,8 @@ export const Button: FC<Props> = ({
       className={`py-3 px-6 mr-2 rounded-md ${className}
           ${
             isPrimary
-              ? "bg-light-blue-600 text-white"
-              : "bg-light-blue-100 text-light-blue-700"
+              ? "bg-light-blue-600 text-white hover:bg-light-blue-500"
+              : "bg-light-blue-100 text-light-blue-700 hover:bg-light-blue-200 "
           } 
         `}
     >

--- a/src/components/Engivia/EngiviaJoinUsers/index.tsx
+++ b/src/components/Engivia/EngiviaJoinUsers/index.tsx
@@ -18,7 +18,11 @@ export const EngiviaJoinUsers: FC<Props> = ({ joinUsers }) => {
                   src={joinUser.image}
                   alt="avatar"
                 />
-                <h1>{joinUser.name}</h1>
+                <h4>
+                  {joinUser.name.length > 10
+                    ? `${joinUser.name.slice(0, 10)}…`
+                    : joinUser.name}
+                </h4>
               </div>
               <span className="py-1 px-3 text-sm text-gray-700 bg-white rounded-full border-2">
                 {`${joinUser.likes} へえ`}

--- a/src/lib/auth/AuthCheck.tsx
+++ b/src/lib/auth/AuthCheck.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/client";
+import { Loader } from "src/components/Loader";
 
 type props = {
   children: any;
@@ -29,5 +30,9 @@ export const Auth = ({ children, pathname }: props) => {
   if (isUser || isNotAuthPaths.includes(pathname)) {
     return children;
   }
-  return <div>Loading...</div>;
+  return (
+    <div>
+      <Loader />
+    </div>
+  );
 };

--- a/src/pages/admin/broadcasting.tsx
+++ b/src/pages/admin/broadcasting.tsx
@@ -368,6 +368,7 @@ const Broadcasting = ({
                             type="button"
                             isSubmitting={inFeatureId === "" ? true : false}
                             isPrimary={true}
+                            className="transition duration-75 transform active:scale-95"
                             onClick={handleTitleCall}
                           >
                             タイトルコールする

--- a/src/pages/broadcast-done.tsx
+++ b/src/pages/broadcast-done.tsx
@@ -37,6 +37,10 @@ const BroadcastDone: NextPage<Props> = ({ engivias }) => {
     setYoutubeURL(broadcastId, convertedUrl);
   };
 
+  const onModalOpen = () => {
+    setIsOpen(true);
+  };
+
   return (
     <BaseLayout title="放送済み">
       <BroadcastTitle broadcast={broadcast} />
@@ -64,7 +68,7 @@ const BroadcastDone: NextPage<Props> = ({ engivias }) => {
               type="button"
               isSubmitting={false}
               onClick={onSetYoutubeURL}
-              isPrimary={true}
+              isPrimary
               className="my-5 text-center"
             >
               保存する
@@ -72,7 +76,7 @@ const BroadcastDone: NextPage<Props> = ({ engivias }) => {
             <Button
               type="button"
               isSubmitting={false}
-              onClick={() => setIsOpen(true)}
+              onClick={onModalOpen}
               isPrimary={false}
               className="my-5 text-center"
             >

--- a/src/pages/broadcast-done.tsx
+++ b/src/pages/broadcast-done.tsx
@@ -1,6 +1,7 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { useRouter } from "next/router";
+import { Dialog, Transition } from "@headlessui/react";
 import { BaseLayout } from "src/components/Layouts/BaseLayout";
 import { BroadcastTitle } from "src/components/Broadcast/BroadcastTitle";
 import { useSubscribeBroadcast } from "src/hooks/useSubscribe";
@@ -19,6 +20,7 @@ type Props = {
 };
 
 const BroadcastDone: NextPage<Props> = ({ engivias }) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [session] = useSession();
   const [url, setUrl] = useState<string>("");
   const router = useRouter();
@@ -70,7 +72,7 @@ const BroadcastDone: NextPage<Props> = ({ engivias }) => {
             <Button
               type="button"
               isSubmitting={false}
-              onClick={onDeleteBroadcast}
+              onClick={() => setIsOpen(true)}
               isPrimary={false}
               className="my-5 text-center"
             >
@@ -79,6 +81,57 @@ const BroadcastDone: NextPage<Props> = ({ engivias }) => {
           </div>
         )}
       </div>
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="overflow-y-auto fixed inset-0 z-10"
+          onClose={() => setIsOpen(false)}
+        >
+          <div className="px-4 min-h-screen text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0 bg-gray-800 bg-opacity-75" />
+            </Transition.Child>
+
+            <span
+              className="inline-block h-screen align-middle"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="inline-block overflow-hidden py-6 px-12 my-8 text-left align-middle bg-white rounded-md shadow-xl transition-all transform">
+                <p className="text-2xl">本当に放送を削除しますか？</p>
+                <div className="mt-6 text-center">
+                  <Button
+                    type="button"
+                    isSubmitting={false}
+                    isPrimary={true}
+                    onClick={onDeleteBroadcast}
+                  >
+                    削除する
+                  </Button>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition>
       {engivias && <EngiviaList engivias={engivias} />}
     </BaseLayout>
   );


### PR DESCRIPTION
## 変更の概要
- ボタンホバー時に少し色が変わる
- タイトルコールボタンを押すと少しアニメーションする
- 参加者一覧表示で、名前が長い参加者は省略表示する
- 認証中のローディングアニメーションを追加
- 管理者の放送終了後画面で放送削除ボタンを押すと確認モーダルが出る

## なぜこの変更をするのか
- タイトルコールを押したのか分かりづらかったため

## やったこと
- タイトルコールボタンコンポーネントにscale追加
![CleanShot 2021-12-10 at 12 29 58](https://user-images.githubusercontent.com/15007672/145512636-d4e77822-ee19-4a03-b982-6475c9ef9f20.gif)


-  Button.tsxコンポーネントにhoverを追加

hover前
![CleanShot 2021-12-10 at 12 25 13](https://user-images.githubusercontent.com/15007672/145512230-31dc5491-b7ee-4336-b14a-1c72a5c13792.png)
hover後
![CleanShot 2021-12-10 at 12 25 18](https://user-images.githubusercontent.com/15007672/145512237-691b02c4-9b1c-48d7-807c-69d31b45e4cb.png)

hover前
![CleanShot 2021-12-10 at 12 25 33](https://user-images.githubusercontent.com/15007672/145512315-b0b06bd0-c3bb-4f78-b4ba-eab8d0a70eb6.png)
hover後
![CleanShot 2021-12-10 at 12 25 40](https://user-images.githubusercontent.com/15007672/145512325-463daf65-c528-4a9e-a22e-e0f00d0af959.png)

- EngiviaJoinUsers.tsxのjoinUser.nameにslice処理を追加

名前が長い時
![CleanShot 2021-12-10 at 12 19 52](https://user-images.githubusercontent.com/15007672/145511772-3668f57c-9240-495b-bc29-874c63e2ff50.png)

名前を省略表示
![CleanShot 2021-12-10 at 12 20 22](https://user-images.githubusercontent.com/15007672/145511776-0b5d94d9-c698-4dee-af44-5db22b5a0e33.png)

## 備考
ご確認よろしくお願いします！
