### PR TITLE
[EGI-55] 管理者ページで参加者人数とエンジビア数がわかる

### DIFF
--- a/src/components/Engivia/EngiviaJoinUsers/index.tsx
+++ b/src/components/Engivia/EngiviaJoinUsers/index.tsx
@@ -18,11 +18,7 @@ export const EngiviaJoinUsers: FC<Props> = ({ joinUsers }) => {
                   src={joinUser.image}
                   alt="avatar"
                 />
-                <h4>
-                  {joinUser.name.length > 10
-                    ? `${joinUser.name.slice(0, 10)}…`
-                    : joinUser.name}
-                </h4>
+                <h1>{joinUser.name}</h1>
               </div>
               <span className="py-1 px-3 text-sm text-gray-700 bg-white rounded-full border-2">
                 {`${joinUser.likes} へえ`}

--- a/src/components/Engivia/EngiviaJoinUsers/index.tsx
+++ b/src/components/Engivia/EngiviaJoinUsers/index.tsx
@@ -18,7 +18,11 @@ export const EngiviaJoinUsers: FC<Props> = ({ joinUsers }) => {
                   src={joinUser.image}
                   alt="avatar"
                 />
-                <h1>{joinUser.name}</h1>
+                <h4>
+                  {joinUser.name.length > 10
+                    ? `${joinUser.name.slice(0, 10)}…`
+                    : joinUser.name}
+                </h4>
               </div>
               <span className="py-1 px-3 text-sm text-gray-700 bg-white rounded-full border-2">
                 {`${joinUser.likes} へえ`}

--- a/src/components/Engivia/SortableItem/index.tsx
+++ b/src/components/Engivia/SortableItem/index.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useSubscribeEngivia } from "src/hooks/useSubscribe";
 import { BroadcastType, EngiviaType } from "src/types/interface";
 
 type Props = {
@@ -14,6 +15,11 @@ export const SortableItem: FC<Props> = ({
   broadcast,
   inFeatureId,
 }) => {
+  const snapshotEngivia = useSubscribeEngivia(
+    broadcast?.id as string,
+    engivia.id
+  );
+
   const isDisable = (engiviaId: string) => {
     /** 放送中でなければ、移動不可 */
     if (broadcast?.status !== "IN_PROGRESS") {
@@ -40,13 +46,27 @@ export const SortableItem: FC<Props> = ({
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       <div className="z-10 py-4 px-4 bg-white rounded-md shadow-md">
         <span className="text-lg">{engivia.body}</span>
-        <div className="flex items-center mt-4">
+        <div className="flex items-center mt-3">
           <img
-            className="mr-2 h-6 rounded-full"
+            className="mr-1 h-5 rounded-full"
             src={engivia.postUser.image}
             alt="avatar"
           />
-          <span>{engivia.postUser.name}</span>
+          <span className="text-sm">{engivia.postUser.name}</span>
+        </div>
+        <div className="mt-3 text-right">
+          <span className="py-1 px-2 mr-2 text-xs text-gray-600 bg-gray-200 rounded-full">
+            {`参加人数: ${
+              snapshotEngivia?.joinUsersCount
+                ? snapshotEngivia?.joinUsersCount
+                : 0
+            }`}
+          </span>
+          <span className="py-1 px-2 text-xs text-gray-600 bg-gray-200 rounded-full">
+            {`エンジビア数: ${
+              snapshotEngivia?.totalLikes ? snapshotEngivia?.totalLikes : 0
+            }`}
+          </span>
         </div>
       </div>
     </div>

--- a/src/hooks/useSubscribe.tsx
+++ b/src/hooks/useSubscribe.tsx
@@ -114,6 +114,24 @@ export const useSubscribeUserEngivia = (broadcastId: string, uid: string) => {
   return userEngivia;
 };
 
+export const useSubscribeEngivia = (broadcastId: string, engiviaId: string) => {
+  const [engivia, setEngivia] = useState<EngiviaType>();
+  useEffect(() => {
+    const unsubscribe = db
+      .collection("broadcasts")
+      .doc(broadcastId)
+      .collection("engivias")
+      .doc(engiviaId)
+      .onSnapshot((snapshot) => {
+        const engiviaDoc = snapshot.data() as EngiviaType;
+        setEngivia(engiviaDoc);
+      });
+    return () => unsubscribe();
+  }, [broadcastId, engiviaId]);
+
+  return engivia;
+};
+
 export const useSubscribeLikes = (
   broadcastId: string,
   engiviaId: string | undefined,


### PR DESCRIPTION
## 変更の概要
管理者ページで参加者人数とエンジビア数がわかる

## なぜこの変更をするのか
管理者が現在の参加者人数とエンジビア数がわからないため

## やったこと

- [ ] エンジビアをonSnapshotする
- [ ] エンジビアカード内に参加者人数とエンジビア数をタグで表示する

## 変更内容
- 少ない文字数の時
![CleanShot 2021-12-10 at 12 09 17](https://user-images.githubusercontent.com/15007672/145510791-0d1077b1-ceef-4a55-8d66-081e1940ba58.png)

- 多い文字数の時
![CleanShot 2021-12-10 at 12 10 30](https://user-images.githubusercontent.com/15007672/145511017-59f64a12-bed1-4cc1-9467-94644fb6c3e2.png)


## 備考
ご確認お願いします！
