### PR TITLE
fix:フィーチャー中のみいいね数が変更できるrulesを削除

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -118,12 +118,6 @@ service cloud.firestore {
                                                       "totalLikes",
                                                       "joinUsersCount"])
       }
-      //いいね数の変更はフィーチャー中のみ許可
-      function incrementLikesInFeature() {
-        return !request.resource.data.hasAny(["totalLikes"])
-                || resource.data.totalLikes == request.resource.data.totalLikes
-                || resource.data.featureStatus == "IN_FEATURE"
-      }
       //adminユーザーが変更不可のフィールド
       function adminNotAllowedChange() {
         return resource.data.body == request.resource.data.body
@@ -150,7 +144,6 @@ service cloud.firestore {
                     && request.resource.data.postUser.id == request.auth.uid;
       allow update: if allowedFields()
                     && validate()
-                    && incrementLikesInFeature()
                     && (
                           isMyPostEngivia(broadcastId, engiviaId)
                           || (isAdminAuthenticated() && adminNotAllowedChange())

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -23,7 +23,7 @@ service cloud.firestore {
     //***************************
     match /users/{userID} {
       function validate() {
-        return 1 <= request.resource.data.name.size() && request.resource.data.name.size() <= 20
+        return 1 <= request.resource.data.name.size() && request.resource.data.name.size() <= 21
       }
       //許可したフィールドのみリクエストに含まれているか
       function allowedFields() {


### PR DESCRIPTION
status変更が不安定なので、修正

## 変更の概要

- 変更の概要
- フィーチャー中のみいいね数が変更できるrulesを削除

## なぜこの変更をするのか

- [slack](https://qinsalon.slack.com/archives/C02H28R8ECW/p1639144798022200)
- タイトルコール時にエンジビアNoの更新・featureStatusの更新されない時がある
⇨ フィーチャー中でないと、いいね数が変更できないルールをがある。⇨変更されない時があるので、ルールを一旦外す
