### PR TITLE
Fix/join user count

### DIFF
--- a/src/components/Engivia/EngiviaList/index.tsx
+++ b/src/components/Engivia/EngiviaList/index.tsx
@@ -11,10 +11,18 @@ const getTotalLikes = (engivia: EngiviaType): number => {
     : 0;
 };
 
+const engiviaLankSort = (engivias: EngiviaType[]): EngiviaType[] => {
+  return engivias.sort((a, b) => {
+    const aLikes = getTotalLikes(a);
+    const bLikes = getTotalLikes(b);
+    return aLikes < bLikes ? 1 : -1;
+  });
+};
+
 export const EngiviaList: FC<Props> = ({ engivias }) => {
   return (
     <>
-      {engivias.map((engivia) => (
+      {engiviaLankSort(engivias).map((engivia) => (
         <div key={engivia?.id} className="mx-auto mb-5 max-w-4xl">
           <div className="py-7 px-10 mb-2 bg-white rounded-lg">
             <div className="flex flex-col items-center mb-10">

--- a/src/components/Engivia/EngiviaList/index.tsx
+++ b/src/components/Engivia/EngiviaList/index.tsx
@@ -5,10 +5,16 @@ type Props = {
   engivias: EngiviaType[];
 };
 
+const getTotalLikes = (engivia: EngiviaType): number => {
+  return engivia.joinUsersCount != 0
+    ? Math.round((engivia.totalLikes / engivia.joinUsersCount) * 5 * 10) / 10
+    : 0;
+};
+
 export const EngiviaList: FC<Props> = ({ engivias }) => {
   return (
     <>
-      {engivias?.map((engivia) => (
+      {engivias.map((engivia) => (
         <div key={engivia?.id} className="mx-auto mb-5 max-w-4xl">
           <div className="py-7 px-10 mb-2 bg-white rounded-lg">
             <div className="flex flex-col items-center mb-10">
@@ -29,7 +35,7 @@ export const EngiviaList: FC<Props> = ({ engivias }) => {
                 </span>
               </div>
               <div className="inline py-3 px-10 text-4xl font-bold text-[#0284C7] bg-[#FEF3C7] rounded-lg">
-                <span>{engivia?.totalLikes}</span>
+                <span>{getTotalLikes(engivia)}</span>
                 <span className="text-xl">へえ</span>
               </div>
             </div>

--- a/src/constant/initialState.ts
+++ b/src/constant/initialState.ts
@@ -21,4 +21,5 @@ export const initialEngiviaInfo: EngiviaType = {
     id: "",
   },
   totalLikes: 0,
+  joinUsersCount: 0,
 };

--- a/src/hooks/useSubscribe.tsx
+++ b/src/hooks/useSubscribe.tsx
@@ -143,7 +143,7 @@ export const useSubscribeTotalLikes = (
   engiviaId: string | undefined
 ) => {
   const soundFlgRef = useRef(false);
-  const [totalLikes, setTotalLikes] = useState<number>(0);
+  const [totalLikes, setTotalLikes] = useState<number | null>(null);
   const [play] = useSound("/hee_low.mp3");
 
   useEffect(() => {
@@ -154,19 +154,22 @@ export const useSubscribeTotalLikes = (
       .doc(engiviaId)
       .onSnapshot(async (snapshot) => {
         const engiviaDoc = await snapshot.data();
-        if (engiviaDoc) {
-          setTotalLikes(engiviaDoc.totalLikes);
-          soundFlgRef.current && play();
-          soundFlgRef.current = true;
-        } else {
-          setTotalLikes(0);
-          soundFlgRef.current = false;
-        }
+        setTotalLikes(engiviaDoc?.totalLikes);
       });
 
     return () => unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [engiviaId]);
+
+  //へぇ数が変わった時だけ音を出す
+  useEffect(() => {
+    if (totalLikes != null) {
+      soundFlgRef.current && play();
+      soundFlgRef.current = true;
+    } else {
+      soundFlgRef.current = false;
+    }
+  }, [totalLikes]);
 
   return totalLikes;
 };

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -142,37 +142,17 @@ export const createEngivia = async (
   };
   engiviaRef.set(engivia);
 
-  return engivia;
-};
-
-export const createJoinUsers = async (
-  broadcastId: string,
-  engiviaId: string,
-  user: ReqUser
-) => {
-  db.collection("broadcasts")
-    .doc(broadcastId)
-    .collection("engivias")
-    .doc(engiviaId)
-    .collection("joinUsers")
-    .doc(user.id)
-    .set({
-      likes: 0,
-      name: user.name,
-      image: user.image,
-      iid: user.id,
-    });
-
-  const engiviaRef = await db
+  const engiviaLengthRef = await db
     .collection("broadcasts")
     .doc(broadcastId)
     .collection("engivias")
-    .doc(engiviaId);
+    .get();
 
-  engiviaRef.set(
-    { joinUsersCount: firebase.firestore.FieldValue.increment(1) },
-    { merge: true }
-  );
+  const engiviaLength = engiviaLengthRef.docs.length;
+  const broadcastRef = await db.collection("broadcasts").doc(broadcastId);
+  broadcastRef.set({ engiviaCount: engiviaLength }, { merge: true });
+
+  return engivia;
 };
 
 export const updateEngivia = async (
@@ -331,17 +311,21 @@ export const addJoinUser = async (
       id: user.id,
     });
 
-  await incrementJoinCount(broadcastId);
+  await incrementJoinCount(broadcastId, engiviaId);
 };
 
-const incrementJoinCount = async (broadcastId: string) => {
-  const engiviaLengthRef = await db
+const incrementJoinCount = async (
+  broadcastId: string,
+  engiviaId: string | undefined
+) => {
+  const engiviaRef = await db
     .collection("broadcasts")
     .doc(broadcastId)
     .collection("engivias")
-    .get();
+    .doc(engiviaId);
 
-  const engiviaLength = engiviaLengthRef.docs.length;
-  const broadcastRef = await db.collection("broadcasts").doc(broadcastId);
-  broadcastRef.set({ engiviaCount: engiviaLength }, { merge: true });
+  engiviaRef.set(
+    { joinUsersCount: firebase.firestore.FieldValue.increment(1) },
+    { merge: true }
+  );
 };

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -15,11 +15,12 @@ export type featureStatusType = "BEFORE" | "IN_FEATURE" | "DONE";
 export type EngiviaType = {
   body: string;
   createdAt: string;
-  engiviaNumber: number;
+  engiviaNumber: number | null;
   featureStatus: featureStatusType;
   id: string;
   postUser: PostUserType;
   totalLikes: number;
+  joinUsersCount: number;
 };
 
 export type BroadcastType = {


### PR DESCRIPTION
## 変更の概要

- joinUserの追加時にjoinUsersCountをカウントアップするように修正
- 放送終了時のへぇ数の表示を修正
- エンジビアの並び順を表示されているいいね数で並び替えるように修正（現状はDBのtotalLikesで並べているので、参加人数を考慮した並び順になっていない）
