### PR TITLE
fix:createUserをする際にawaitするように修正

### DIFF
--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -19,9 +19,10 @@ export type ResUser = ReqUser & {
 
 const adminUsers = ["U01FE9AJ4A2"];
 
-export const createUser = (user: ReqUser) => {
+export const createUser = async (user: ReqUser) => {
   const isAdmin = adminUsers.includes(user.id);
-  db.collection("users")
+  await db
+    .collection("users")
     .doc(user.id)
     .set({ ...user, isAdmin }, { merge: true });
 };

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -48,7 +48,8 @@ const options = {
         if (user !== null) {
           await customTokenSignIn(user.id, user.email);
 
-          (await getUser(user.id)) ?? createUser(toReqUser(user, account));
+          (await getUser(user.id)) ??
+            (await createUser(toReqUser(user, account)));
           const data = await getUser(user.id);
           setResUser(user, data as ResUser);
           return true;


### PR DESCRIPTION
## 変更の概要

- 初回ログイン時のユーザー作成で`await`するように修正

## なぜこの変更をするのか

- 初回ログイン時に `Access Denied`のエラーが出るバグが出ていた。　原因としてはawaitしていないので、ユーザー作成前にユーザー取得処理がされてしまっていると思われる。
> ※ なぜか1度目のログインに失敗する場合があります。
原因不明ですが、再度ログインを試みると成功したり、別ブラウザだと成功します。
- [slack](https://qinsalon.slack.com/archives/C01FM1DFXFU/p1640239193456800)


## 仮説

元コード
```typescript
(await getUser(user.id)) ?? createUser(toReqUser(user, account));
const data = await getUser(user.id);
setResUser(user, data as ResUser);
```
1. ` createUser(toReqUser(user, account));`の処理時に awaitをしていないので、処理タイミングによってユーザー作成前に、次処理の`const data = await getUser(user.id);`が動いてしまう
2. createUserが完了していないので、getUserではUser情報の取得ができずに、sessionには`null` が詰められる
3. sessionにnullが入っているので、sessionから`user.id`などが取得できずにその後の処理でエラーが出ていると思われる。
※2回目以降にエラーが出ないのは、 1回目のログインでuserコレクションが作成済み。
⇨`getUser`はawaitしているので、userコレクションが作成されていればnullにはならずに取得できる

## 検証
```typescript
const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
export const createUser = (user: ReqUser) => {
  const isAdmin = adminUsers.includes(user.id);
  sleep(10000).then((val) =>
    db
      .collection("users")
      .doc(user.id)
      .set({ ...user, isAdmin }, { merge: true })
  );
};
```
1. ローカルで`createUser`を上記のように修正（user作成までに10秒以上かかるようにする）
2. firestoreでuser情報を削除し、ログイン
3. `createUser`の処理終了を待たずに、`getUser`が実行されエラーが再現できた。（5回くらい検証済）
4. `createUser`でawaitするようにしたところ、sleepを10秒以上した状態でもエラーが出なくなることを確認
